### PR TITLE
Fix Display Underscaling After Sleep

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -527,6 +527,8 @@
 				<data>AQAAAA==</data>
 				<key>framebuffer-fbmem</key>
 				<data>AACQAA==</data>
+				<key>framebuffer-flags</key>
+				<data>CgvjAA==</data>
 				<key>framebuffer-patch-enable</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-portcount</key>


### PR DESCRIPTION
When using HiDPI display resolutions in macOS, the display is underscaled when waking from sleep. This frame buffer flag fixes that.